### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ With DecaUI, developers can use the centralized theming system anywhere within t
 </Box>
 ```
 
-## Our focus is consistancy
+## Our focus is consistency
 
-The main problem with other UI libraries is that it's confusing to create consistant webpage layouts with them. DecaUI allows developers to utilize a root theme object which serves properties following the [System UI](https://github.com/system-ui/theme-specification) specification.
+The main problem with other UI libraries is that it's confusing to create consistent webpage layouts with them. DecaUI allows developers to utilize a root theme object which serves properties following the [System UI](https://github.com/system-ui/theme-specification) specification.
 
 ## License
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
`docs update`

- **What is the current behavior?** (You can also link to an open issue here)
Different variations of `Consistent` are spelt incorrectly.

- **What is the new behavior (if this is a feature change)?**
They are now spelt correctly.

- **Other information**:
